### PR TITLE
Fix game loading to start on button click

### DIFF
--- a/game.js
+++ b/game.js
@@ -43,6 +43,11 @@ function setup() {
     noLoop(); // Don't start the game until the user clicks the start button
     canvas.elt.addEventListener('wheel', handleMouseWheel);
     initializeBricks(); // Initialize bricks on setup
+    paddle = new Paddle();
+    balls = [new Ball()]; // Initialize with one ball
+    brickWidth = width / cols;
+    powerUps = []; // Clear existing power-ups
+    particles = []; // Clear existing particles
 }
 
 function initializeBricks() {
@@ -62,12 +67,6 @@ function startGame() {
     document.getElementById('retry-button').style.display = 'none'; // Hide the retry button
     document.getElementById('message-container').innerHTML = ''; // Clear message container
     score = 0; // Reset the score
-    paddle = new Paddle();
-    balls = [new Ball()]; // Initialize with one ball
-    brickWidth = width / cols;
-    powerUps = []; // Clear existing power-ups
-    particles = []; // Clear existing particles
-    initializeBricks(); // Initialize bricks for the game
     loop(); // Start the game loop
 }
 


### PR DESCRIPTION
Move the initialization of game elements to the `setup()` function to ensure the game loads completely before the "Start Game" button is clicked.

* **Initialization in `setup()` function**
  - Initialize bricks, paddle, balls, brickWidth, powerUps, and particles in the `setup()` function.

* **Modification in `startGame()` function**
  - Remove the initialization of game elements from the `startGame()` function.
  - Ensure the `startGame()` function only resumes the game loop and hides the "Start Game" and "Retry" buttons.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/JuanGdev/SANDA-Pre-GameJam/pull/1?shareId=2e1f3f28-130e-45c5-a6dc-10135e3005bd).