### PR TITLE
Fix the bug that makes the bricks don't be loaded in the initial state of the game

### DIFF
--- a/game.js
+++ b/game.js
@@ -67,6 +67,10 @@ function startGame() {
     document.getElementById('retry-button').style.display = 'none'; // Hide the retry button
     document.getElementById('message-container').innerHTML = ''; // Clear message container
     score = 0; // Reset the score
+    initializeBricks(); // Ensure bricks are loaded when the game starts
+    balls = [new Ball()]; // Reset the balls array to ensure a new ball is created
+    powerUps = []; // Reset the powerUps array to ensure no power-ups are active
+    particles = []; // Reset the particles array to ensure no particles are active
     loop(); // Start the game loop
 }
 


### PR DESCRIPTION
Fix the bug that prevents bricks from being loaded in the initial state of the game.

* Call `initializeBricks` in the `startGame` function to ensure bricks are loaded when the game starts.
* Reset the `balls` array in the `startGame` function to ensure a new ball is created.
* Reset the `powerUps` array in the `startGame` function to ensure no power-ups are active.
* Reset the `particles` array in the `startGame` function to ensure no particles are active.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/JuanGdev/SANDA-Pre-GameJam/pull/2?shareId=b58e0d6a-f459-49f7-ba5c-d137f59bbf1d).